### PR TITLE
FIX: Fix CI script on develop and main branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,32 @@ executors:
 set_env: &set_env
   name: Setup Environment Variables
   command: |
+    if [ ! -z "$CIRCLE_PULL_REQUEST" ]; then
+      # Use the base commit of PR as the affected base.
 
-    echo 'Fetching Base Commit from GitHub'
-    # Get the PR number from env for different kinds of PR
-    echo 'export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"' >> $BASH_ENV
-    source $BASH_ENV
-    # Obtain the SHA via Github API
-    echo "export CIRCLE_PR_BASE_SHA=`curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.sha'`" >> $BASH_ENV
-    # Set the affected args for nx affect xxx commands
-    echo 'export AFFECTED_ARGS="--base=${CIRCLE_PR_BASE_SHA}"' >> $BASH_ENV
+      echo 'Fetching Base Commit from GitHub'
+      # Get the PR number from env for different kinds of PR
+      echo 'export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"' >> $BASH_ENV
+      source $BASH_ENV
+      
+      # Obtain the SHA via Github API
+      echo "export CIRCLE_PR_BASE_SHA=`curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.sha'`" >> $BASH_ENV
+      # Set the affected args for nx affect xxx commands
+      echo 'export AFFECTED_ARGS="--head=HEAD --base=${CIRCLE_PR_BASE_SHA}"' >> $BASH_ENV
+
+    elif [ "$CIRCLE_BRANCH" == "develop" ]; then
+      # Merge into develop branch, use main branch as the base.
+
+      echo "Using main branch as the base"
+      echo 'export AFFECTED_ARGS="--head=HEAD --base=main"' >> $BASH_ENV 
+
+    else
+
+      echo "Testing/Linting on all packages"
+      echo 'export AFFECTED_ARGS="--all"' >> $BASH_ENV 
+
+    fi
+
     # Set the memory size for node processes
     echo 'export NODE_OPTIONS="--max_old_space_size=6144"' >> $BASH_ENV
     source $BASH_ENV
@@ -87,7 +104,7 @@ jobs:
       - restore_cache:
           <<: *yarn_cache
       - run: yarn nx workspace-lint
-      - run: yarn nx affected --target=lint --head=HEAD --maxWarnings=0 ${AFFECTED_ARGS}
+      - run: yarn nx affected --target=lint --maxWarnings=0 ${AFFECTED_ARGS}
 
   test:
     executor: node-executor
@@ -100,7 +117,7 @@ jobs:
       - restore_cache:
           keys:
             - codecov-0.1.0_4653
-      - run: yarn nx affected --target=test --head=HEAD --ci --coverage --maxWorkers=2 --coverageReporters=lcov ${AFFECTED_ARGS}
+      - run: yarn nx affected --target=test --ci --coverage --maxWorkers=2 --coverageReporters=lcov ${AFFECTED_ARGS}
         # --maxWorkers=2 is required because we'll run virtual machine with 32 cores CPU (with actually 4 CPI), jest spawns lots of workers if we don't fix the worker size.
         # https://support.circleci.com/hc/en-us/articles/360005442714-Your-test-tools-are-smart-and-that-s-a-problem-Learn-about-when-optimization-goes-wrong-
       - run: ./codecov -t ${CODECOV_TOKEN}


### PR DESCRIPTION
### What's happened
We used the wrong `--base` argument when running tests on `develop` and `main` branches, this PR set the correct base for them:
- In develop branch: diff with `main` branch.
- In main branch: run all tests.