### PR TITLE
Chore: Upload report with flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,24 @@ jobs:
       - restore_cache:
           keys:
             - codecov-0.1.0_4653
+      - run: rm -rf ./coverage
+        # Clear coverage folder
       - run: yarn nx affected --target=test --ci --coverage --maxWorkers=2 --coverageReporters=lcov ${AFFECTED_ARGS}
         # --maxWorkers=2 is required because we'll run virtual machine with 32 cores CPU (with actually 4 CPI), jest spawns lots of workers if we don't fix the worker size.
         # https://support.circleci.com/hc/en-us/articles/360005442714-Your-test-tools-are-smart-and-that-s-a-problem-Learn-about-when-optimization-goes-wrong-
-      - run: ./codecov -t ${CODECOV_TOKEN}
+      - run:
+          name: upload reports with flags
+          command: |
+            if [ -d "coverage/packages" ] 
+            then
+              for path in $(find coverage/packages -maxdepth 1 -type d | grep coverage/packages/); do
+                package=${path##coverage/packages/}
+                echo "Uploading coverage report for package: $package"
+                ./codecov -t ${CODECOV_TOKEN} -f coverage/packages/$package/lcov.info -F $package
+              done
+            else
+              echo "No coverage report found."
+            fi
 
 workflows:
   version: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    # Reference of past coverage for tests that are not run on current commit.
+    # https://docs.codecov.com/docs/carryforward-flags
+    carryforward: true

--- a/packages/core/test/utils/normalizedStringValue.spec.ts
+++ b/packages/core/test/utils/normalizedStringValue.spec.ts
@@ -1,0 +1,39 @@
+import { normalizeStringValue } from '@vulcan-sql/core';
+
+it.each([
+  ['number', '', 'test must be number'],
+  ['number', 'a', 'test must be number'],
+  ['number', 'true', 'test must be number'],
+  ['boolean', 'a', 'test must be boolean'],
+  ['boolean', '12345', 'test must be boolean'],
+  ['date', '', 'test must be date'],
+  ['date', 'a', 'test must be date'],
+  ['date', 'true', 'test must be date'],
+])(
+  `Normalizer should throw error with type %s and value %p`,
+  (type, value, errorMessage) => {
+    expect(() => normalizeStringValue(value, 'test', type)).toThrow(
+      errorMessage
+    );
+  }
+);
+
+it.each([
+  ['number', '1234', 1234],
+  ['number', '-1234', -1234],
+  ['number', '0', 0],
+  ['boolean', '', true],
+  ['boolean', '1', true],
+  ['boolean', 'true', true],
+  ['boolean', '0', false],
+  ['boolean', 'false', false],
+  ['date', '2022-08-23 14:44:23', new Date('2022-08-23 14:44:23')],
+  ['string', '1234', '1234'],
+  ['string', 'true', 'true'],
+  ['string', '', ''],
+])(
+  `Normalizer should return correct value with type %s and value %p`,
+  (type, value, expectedValue) => {
+    expect(normalizeStringValue(value, 'test', type)).toEqual(expectedValue);
+  }
+);


### PR DESCRIPTION
### What's happened

We only run affected packages with CI, so we won't get coverage reports for all packages. But with codecov [merge reports](https://docs.codecov.com/docs/merging-reports) feature, it'll wait for us to send all of reports.

### Solution
Use flags and enable carryforward option, we can use previous reports when some packages are not changed.

https://about.codecov.io/blog/new-product-test-only-what-you-change-with-carryforward-flags/
Flags: https://docs.codecov.com/docs/flags#tracking-flag-coverage-over-time
Carryforward: https://docs.codecov.com/docs/carryforward-flags